### PR TITLE
Fixes references to missing files and corrects locations

### DIFF
--- a/tools/convert-mhd-phantom-to-spinscenario-h5.cpp
+++ b/tools/convert-mhd-phantom-to-spinscenario-h5.cpp
@@ -4,8 +4,8 @@
 #include <fstream>
 #include <filesystem>
 
-#include <rarray>
-#include <rarrayio>
+#include "rarray"
+#include "rarrayio"
 
 #include "H5Cpp.h"
 

--- a/tools/convert-spinscenario-h5-results-to-mhd.cpp
+++ b/tools/convert-spinscenario-h5-results-to-mhd.cpp
@@ -7,13 +7,12 @@
 #include <fstream>
 #include <filesystem>
 
-#include <rarray>
-#include <rarrayio>
+#include "rarray"
+#include "rarrayio"
 
 #include "H5Cpp.h"
 
-#include <jp-echo.hpp>
-#include <jp-mhd-3d.hpp>
+#include "misc.h"
 
 using namespace std;
 using namespace H5;

--- a/tools/mirror-mhd.cpp
+++ b/tools/mirror-mhd.cpp
@@ -1,5 +1,4 @@
-#include "/home/jpeter/cpp/include/jp.h"
-#include "/home/jpeter/cpp/include/jp-mhd.h"
+#include "misc.h"
 
 using namespace std;
 


### PR DESCRIPTION
This corrects the search location for rarray files and removes missing files from the include list.
Otherwise ```make all && make -f makefile-h5 all``` fails under Ubuntu 18.04.5 LTS with GCC 9.